### PR TITLE
don't log force delete events

### DIFF
--- a/src/EventType.php
+++ b/src/EventType.php
@@ -8,4 +8,5 @@ class EventType
     const UPDATED = 2;
     const DELETED = 3;
     const RESTORED = 4;
+    const FORCE_DELETED = 5;
 }

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -31,6 +31,9 @@ abstract class BaseModel extends Model
             case EventType::RESTORED:
                 $changes = $model->getChanges();
                 break;
+            case EventType::FORCE_DELETED:
+                return; // if force deleted we want to stop execution here as there would be nothing to correlate records to
+                break;
         }
 
         collect($changes)

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -35,7 +35,13 @@ abstract class BaseModel extends Model
 
         collect($changes)
             ->except(config('model-auditlog.global_ignored_fields'))
-            ->except([$model->getKeyName()]) // Ignore the current model's primary key
+            ->except([
+                $model->getKeyName(), // Ignore the current model's primary key
+                'created_at',
+                'updated_at',
+                'date_created',
+                'date_modified',
+            ])
             ->each(function ($change, $key) use ($event_type, $model) {
                 $log = new static();
                 $log->event_type = $event_type;

--- a/src/Observers/AuditLogObserver.php
+++ b/src/Observers/AuditLogObserver.php
@@ -30,8 +30,16 @@ class AuditLogObserver
      */
     public function deleted($model) : void
     {
+        /*
+         * If a model is hard deleting, either via a force delete or that model does not implement
+         * the SoftDeletes trait we should tag it as such so logging doesn't occur down the pipe.
+         */
+        if (! method_exists($model, 'isForceDeleting') || $model->isForceDeleting()) {
+            $event = EventType::FORCE_DELETED;
+        }
+
         $this->getAuditLogModel($model)
-            ->recordChanges(EventType::DELETED, $model);
+            ->recordChanges($event ?? EventType::DELETED, $model);
     }
 
     /**

--- a/tests/Fakes/Models/NonSoftDeletePost.php
+++ b/tests/Fakes/Models/NonSoftDeletePost.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OrisIntel\AuditLog\Tests\Fakes\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use OrisIntel\AuditLog\Traits\AuditLoggable;
+
+class NonSoftDeletePost extends Model
+{
+    use AuditLoggable;
+
+    protected $guarded = [];
+
+    protected $table = 'posts';
+}

--- a/tests/Fakes/Models/NonSoftDeletePostAuditLog.php
+++ b/tests/Fakes/Models/NonSoftDeletePostAuditLog.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OrisIntel\AuditLog\Tests\Fakes\Models;
+
+use OrisIntel\AuditLog\Models\BaseModel;
+
+class NonSoftDeletePostAuditLog extends BaseModel
+{
+    public $timestamps = false;
+
+    public $table = 'posts_auditlog';
+}

--- a/tests/PostModelTest.php
+++ b/tests/PostModelTest.php
@@ -5,6 +5,7 @@ namespace OrisIntel\AuditLog\Tests;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Collection;
 use OrisIntel\AuditLog\EventType;
+use OrisIntel\AuditLog\Tests\Fakes\Models\NonSoftDeletePost;
 use OrisIntel\AuditLog\Tests\Fakes\Models\Post;
 use OrisIntel\AuditLog\Tests\Fakes\Models\PostAuditLog;
 
@@ -90,6 +91,38 @@ class PostModelTest extends TestCase
         $this->assertEquals('deleted_at', $last->field_name);
         $this->assertNull($last->field_value_old);
         $this->assertNotEmpty($last->field_value_new);
+    }
+
+    /** @test */
+    public function force_deleting_a_post_does_not_trigger_a_revision()
+    {
+        /** @var Post $post */
+        $post = Post::create([
+            'title'     => 'Test',
+            'posted_at' => '2019-04-05 12:00:00',
+        ]);
+
+        $this->assertEquals(2, $post->auditLogs()->count());
+
+        $post->forceDelete();
+
+        $this->assertEquals(2, $post->auditLogs()->count());
+    }
+
+    /** @test */
+    public function deleting_a_non_soft_deleting_post_does_not_trigger_a_revision()
+    {
+        /** @var Post $post */
+        $post = NonSoftDeletePost::create([
+            'title'     => 'Test',
+            'posted_at' => '2019-04-05 12:00:00',
+        ]);
+
+        $this->assertEquals(2, $post->auditLogs()->count());
+
+        $post->forceDelete();
+
+        $this->assertEquals(2, $post->auditLogs()->count());
     }
 
     /** @test */


### PR DESCRIPTION
Doing so would cause conflicts in the database because there is nothing to correlate to which causes FK relationships to fail.

Additionally adding default timestamps to the field name blacklist as they are redundant.