### PR TITLE
support ignoring fields at the model level

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ php artisan make:model-auditlog "\App\User"
 
 Replace `\App\User` with your own model name. Model / table options can be tweaked in the config file.
 
+If you need to ignore specific fields on your model, extend the `getAuditLogIgnoredFields()` method and return an array of fields.
+```php
+public function getAuditLogIgnoredFields() : array
+{
+    return ['posted_at'];
+}
+```
+
 ### Testing
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -43,10 +43,23 @@ php artisan make:model-auditlog "\App\User"
 Replace `\App\User` with your own model name. Model / table options can be tweaked in the config file.
 
 If you need to ignore specific fields on your model, extend the `getAuditLogIgnoredFields()` method and return an array of fields.
+
 ```php
 public function getAuditLogIgnoredFields() : array
 {
     return ['posted_at'];
+}
+```
+
+Using that functionality, you can add more custom logic around what should be logged. An example might be to not log the title changes of a post if the post has not been published yet.
+```php
+public function getAuditLogIgnoredFields() : array
+{
+    if ($this->postHasBeenPublished()) {
+        return ['title'];
+    }
+
+    return [];
 }
 ```
 

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -38,6 +38,7 @@ abstract class BaseModel extends Model
 
         collect($changes)
             ->except(config('model-auditlog.global_ignored_fields'))
+            ->except($model->getAuditLogIgnoredFields())
             ->except([
                 $model->getKeyName(), // Ignore the current model's primary key
                 'created_at',

--- a/src/Traits/AuditLoggable.php
+++ b/src/Traits/AuditLoggable.php
@@ -44,6 +44,16 @@ trait AuditLoggable
     }
 
     /**
+     * Get fields that should be ignored from the auditlog for this model.
+     *
+     * @return array
+     */
+    public function getAuditLogIgnoredFields() : array
+    {
+        return [];
+    }
+
+    /**
      * Get the audit logs for this model.
      *
      * @return HasMany|null

--- a/tests/Fakes/Models/IgnoredFieldsPost.php
+++ b/tests/Fakes/Models/IgnoredFieldsPost.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OrisIntel\AuditLog\Tests\Fakes\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use OrisIntel\AuditLog\Traits\AuditLoggable;
+
+class IgnoredFieldsPost extends Model
+{
+    use AuditLoggable;
+
+    protected $guarded = [];
+
+    protected $table = 'posts';
+
+    public function getAuditLogIgnoredFields() : array
+    {
+        return ['posted_at'];
+    }
+}

--- a/tests/Fakes/Models/IgnoredFieldsPostAuditLog.php
+++ b/tests/Fakes/Models/IgnoredFieldsPostAuditLog.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OrisIntel\AuditLog\Tests\Fakes\Models;
+
+use OrisIntel\AuditLog\Models\BaseModel;
+
+class IgnoredFieldsPostAuditLog extends BaseModel
+{
+    public $timestamps = false;
+
+    public $table = 'posts_auditlog';
+}

--- a/tests/PostModelTest.php
+++ b/tests/PostModelTest.php
@@ -5,6 +5,7 @@ namespace OrisIntel\AuditLog\Tests;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Collection;
 use OrisIntel\AuditLog\EventType;
+use OrisIntel\AuditLog\Tests\Fakes\Models\IgnoredFieldsPost;
 use OrisIntel\AuditLog\Tests\Fakes\Models\NonSoftDeletePost;
 use OrisIntel\AuditLog\Tests\Fakes\Models\Post;
 use OrisIntel\AuditLog\Tests\Fakes\Models\PostAuditLog;
@@ -147,5 +148,21 @@ class PostModelTest extends TestCase
         $last = $post->auditLogs()->where('event_type', EventType::RESTORED)->first();
         $this->assertEquals('deleted_at', $last->field_name);
         $this->assertNull($last->field_value_new);
+    }
+
+    /** @test */
+    public function fields_can_be_ignored()
+    {
+        /** @var Post $post */
+        $post = IgnoredFieldsPost::create([
+            'title'     => 'Test',
+            'posted_at' => '2019-04-05 12:00:00',
+        ]);
+
+        $this->assertEquals(1, $post->auditLogs()->count());
+
+        $post->update(['posted_at' => now()]);
+
+        $this->assertEquals(1, $post->auditLogs()->count());
     }
 }


### PR DESCRIPTION
Added a `getAuditLogIgnoredFields()` method on the `Auditloggable` trait to support ignoring fields on a per model basis.