### PR TITLE
Allow $primaryKey for Pivot

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ class PostTagAuditLog extends BaseModel
 
 For a working example of pivots with the audit log, see `laravel-model-auditlog/tests/Fakes`, which contains working migrations and models.
 
+Note:
+Both models must use the AuditLoggable trait (ex: Post and Tag) so that `$post->tags()->sync([...])` will work.
+
 ### Testing
 
 ``` bash

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -106,10 +106,13 @@ abstract class BaseModel extends Model
      */
     public function getPivotChanges($pivot, $model, array $pivotIds) : array
     {
+        $columns = (new $pivot())->getAuditLogForeignKeyColumns();
+        $key = in_array($model->getForeignKey(), $columns) ? $model->getForeignKey() : $model->getKeyName();
+
         $changes = [];
-        foreach ((new $pivot())->getAuditLogForeignKeyColumns() as $auditColumn => $pivotColumn) {
-            foreach ($pivotIds as $id => $pivotId) {
-                if ($pivotColumn !== $model->getForeignKey()) {
+        foreach ($pivotIds as $id => $pivotId) {
+            foreach ($columns as $auditColumn => $pivotColumn) {
+                if ($pivotColumn !== $key) {
                     $changes[$id][$auditColumn] = $pivotId;
                 } else {
                     $changes[$id][$auditColumn] = $model->getKey();

--- a/tests/Fakes/Models/Post.php
+++ b/tests/Fakes/Models/Post.php
@@ -15,9 +15,15 @@ class Post extends Model
 
     protected $guarded = [];
 
+    protected $primaryKey = 'post_id';
+
     public function tags()
     {
-        return $this->belongsToMany(Tag::class)
+        return $this->belongsToMany(Tag::class,
+            'post_tag',
+            'post_id',
+            'tag_id'
+        )
             ->using(PostTag::class);
     }
 }

--- a/tests/Fakes/migrations/2019_04_05_101112_add_posts_table.php
+++ b/tests/Fakes/migrations/2019_04_05_101112_add_posts_table.php
@@ -14,7 +14,7 @@ class AddPostsTable extends Migration
     public function up()
     {
         Schema::create('posts', function (Blueprint $table) {
-            $table->increments('id');
+            $table->increments('post_id');
             $table->string('title');
             $table->timestamp('posted_at')->index();
             $table->timestamps();

--- a/tests/PostTagModelTest.php
+++ b/tests/PostTagModelTest.php
@@ -103,14 +103,12 @@ class PostTagModelTest extends TestCase
     public function deleting_a_post_tag_does_not_trigger_a_revision()
     {
         $tag1 = Tag::create([
-            'id'        => 50,
             'title'     => 'Here is a comment!',
             'posted_at' => '2019-04-05 12:00:00',
         ]);
 
         /** @var Post $post */
         $post = Post::create([
-            'id'        => 2000,
             'title'     => 'Test',
             'posted_at' => '2019-04-05 12:00:00',
         ]);
@@ -122,10 +120,10 @@ class PostTagModelTest extends TestCase
         //hasMany relationship works on tag model to audit log
         $this->assertEquals(2, $tag1->auditLogs()->count());
         //Record correct in pivot
-        $this->assertEquals(1, PostTag::where('post_id', 2000)->where('tag_id', 50)->count());
+
+        $this->assertEquals(1, PostTag::where('post_id', 1)->where('tag_id', 1)->count());
 
         $tag2 = Tag::create([
-            'id'        => 99,
             'title'     => 'Here is another comment!',
             'posted_at' => '2019-04-06 12:00:00',
         ]);


### PR DESCRIPTION
If a different key is set with $primaryKey, use that instead of the Laravel generated FK.